### PR TITLE
fix patching of nested structs

### DIFF
--- a/struct-patch-derive/src/lib.rs
+++ b/struct-patch-derive/src/lib.rs
@@ -132,7 +132,7 @@ pub fn derive_patch(item: TokenStream) -> TokenStream {
                         }) => {
                             if let Lit::Str(l) = &lit.lit {
                                 let ident = Some(Ident::new(
-                                    l.value().to_string().trim_matches('"'),
+                                    l.value().trim_matches('"'),
                                     Span::call_site(),
                                 ));
                                 (quote!(Option<#ident>), true)

--- a/struct-patch/src/lib.rs
+++ b/struct-patch/src/lib.rs
@@ -142,4 +142,40 @@ mod tests {
         item.apply(patch);
         assert_eq!(item, Item { id: 1, data: 15 });
     }
+
+    #[test]
+    fn test_nested() {
+        #[derive(PartialEq, Debug, Patch, Deserialize)]
+        #[patch_derive(PartialEq, Debug, Deserialize)]
+        struct B {
+            c: u32,
+            d: u32,
+        }
+
+        #[derive(PartialEq, Debug, Patch, Deserialize)]
+        #[patch_derive(PartialEq, Debug, Deserialize)]
+        struct A {
+            #[patch_name = "BPatch"]
+            b: B,
+        }
+
+        let mut a = A {
+            b: B { c: 0, d: 0 },
+        };
+        let data = r#"{ "b": { "c": 1 } }"#;
+        let patch: APatch = serde_json::from_str(data).unwrap();
+        // assert_eq!(
+        //     patch,
+        //     APatch {
+        //         b: Some(B { id: 1 })
+        //     }
+        // );
+        a.apply(patch);
+        assert_eq!(
+            a,
+            A {
+                b: B { c: 1, d: 0 }
+            }
+        );
+    }
 }


### PR DESCRIPTION
when nesting structs, the patches should also use nested patches instead of the original nested structs, otherwise a patch with a nested structure can not be deserialized from json (the original non-patched struct is used to deserialize the json and if fields are missing, it fails)

this pr solves the problem by introducing #[patch_name = <name>] attribute that can be added to fields. The name should point to the patch structure that should be used instead of the original. This attribute then causes 2 things to happen:
1. The new name is used for the type of the field in generated code
2. It generates different methods in the Patch traits based on if the fields are renamed or not

This should fix #21 