### PR TITLE
make `#![no_std]` compatible

### DIFF
--- a/struct-patch/src/lib.rs
+++ b/struct-patch/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 //!
 //! More details on how to use the the derive macro, including what attributes are available, are available under [`Patch`]
+#![cfg_attr(not(test), no_std)]
 
 #[doc(hidden)]
 pub use struct_patch_derive::Patch;


### PR DESCRIPTION
Add the attribute gate `#![cfg_attr(not(test), no_std)]` to allow for use in `no_std` environments.