### PR TITLE
feat: 'add' field attribute for custom implementation

### DIFF
--- a/struct-patch/src/std.rs
+++ b/struct-patch/src/std.rs
@@ -64,6 +64,19 @@ where
     }
 }
 
+#[cfg(all(feature = "option", feature = "op"))]
+pub fn add_option<T>(a: Option<T>, b: Option<T>) -> Option<T>
+where
+    T: std::ops::Add<Output = T>,
+{
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a + b),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate as struct_patch;


### PR DESCRIPTION
Change the behavior between two patches when a field is defined in both patches:

- if the field as an `add` attribute defined with the function to use for the add, we use this function
- else if the field as been renamed, it's a sub-patch, so it has un `Add` implementation that we use
- else we use the value of the right-end patch field

This makes a default behavior for the `Add` that can be customized by the dev for both renamed and not renamed fields.
