### PR TITLE
feat: Merge trait to merge patches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
           nix develop -c cargo run --features=std --example option
           nix develop -c cargo test --features=std
 
+      - name: Test with merge features
+        run: |
+          nix develop -c cargo run --features=option --features=merge --example option
+          nix develop -c cargo run --features=merge --example op
+          nix develop -c cargo test --features=merge
+
       - name: Test with option features
         run: |
           nix develop -c cargo run --features=none_as_default --example option

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The [examples][examples] demo following scenarios.
 This crate also includes the following optional features:
 - `status`(default): implements the `PatchStatus` trait for the patch struct, which provides the `is_empty` method.
 - `op` (default): provide operators `<<` for instance and patch, and `+` for patches
+- `merge` (optional): implements the `Merge` trait for the patch struct, which provides the `merge` method.
 - `std`(optional):
   - `box`: implements the `Patch<Box<P>>` trait for `T` where `T` implements `Patch<P>`.
     This let you patch a boxed (or not) struct with a boxed patch.

--- a/struct-patch-derive/Cargo.toml
+++ b/struct-patch-derive/Cargo.toml
@@ -21,6 +21,7 @@ syn = { version =  "2.0", features = ["parsing"] }
 [features]
 status = []
 op = []
+merge = []
 
 [dev-dependencies]
 pretty_assertions_sorted = "1.2.3"

--- a/struct-patch/Cargo.toml
+++ b/struct-patch/Cargo.toml
@@ -26,6 +26,9 @@ status = [
 op = [
     "struct-patch-derive/op"
 ]
+merge = [
+    "struct-patch-derive/merge"
+]
 
 std = ["box", "option"]
 box = []

--- a/struct-patch/examples/op.rs
+++ b/struct-patch/examples/op.rs
@@ -52,11 +52,17 @@ fn main() {
     // Will be handdled as the discussion
     // https://github.com/yanganto/struct-patch/pull/32#issuecomment-2283154990
 
-    let final_item_with_bracket = item.clone() << (conflict_patch.clone() << the_other_patch.clone());
-    let final_item_without_bracket = item.clone() << conflict_patch << the_other_patch.clone();
-    assert_eq!(final_item_with_bracket, final_item_without_bracket);
-    assert_eq!(final_item_with_bracket.field_int, 2);
+    let final_item_without_bracket =
+        item.clone() << conflict_patch.clone() << the_other_patch.clone();
     assert_eq!(final_item_without_bracket.field_int, 2);
+
+    #[cfg(feature = "merge")]
+    {
+        let final_item_with_bracket =
+            item.clone() << (conflict_patch.clone() << the_other_patch.clone());
+        assert_eq!(final_item_with_bracket, final_item_without_bracket);
+        assert_eq!(final_item_with_bracket.field_int, 2);
+    }
 
     let final_item_from_merge = item.clone() << (another_patch.clone() + the_other_patch.clone());
     assert_eq!(final_item_from_merge.field_string, "from another patch");

--- a/struct-patch/src/std.rs
+++ b/struct-patch/src/std.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "merge", feature = "option"))]
+use crate::Merge;
 #[cfg(any(feature = "box", feature = "option"))]
 use crate::Patch;
 #[cfg(feature = "box")]
@@ -136,6 +138,24 @@ where
 
     fn new_empty_patch() -> Option<P> {
         Some(T::new_empty_patch())
+    }
+}
+
+#[cfg(all(feature = "option", feature = "merge"))]
+impl<T> Merge for Option<T>
+where
+    T: Merge,
+{
+    fn merge(self, other: Self) -> Self {
+        if let Some(other) = other {
+            if self.is_some() {
+                Some(self.unwrap().merge(other))
+            } else {
+                Some(other)
+            }
+        } else {
+            None
+        }
     }
 }
 

--- a/struct-patch/src/traits.rs
+++ b/struct-patch/src/traits.rs
@@ -97,3 +97,9 @@ pub trait PatchStatus {
     /// Returns `true` if all fields are `None`, `false` otherwise.
     fn is_empty(&self) -> bool;
 }
+
+#[cfg(feature = "merge")]
+/// A patch struct that can be merged to another one
+pub trait Merge {
+    fn merge(self, other: Self) -> Self;
+}


### PR DESCRIPTION
Creation of a `Merge` trait implemented by the patch structs to merge two patches together.

This fix the `<<` operator between two patches.