### PR TITLE
resolve E0599 when derived without importing trait into current scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "struct-patch",
     "struct-patch-derive",
@@ -6,7 +7,7 @@ members = [
 
 [workspace.package]
 authors = ["Antonio Yang <yanganto@gmail.com>"]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 categories = ["development-tools"]
 keywords = ["struct", "patch", "macro", "derive", "overlay"]

--- a/struct-patch-derive/src/lib.rs
+++ b/struct-patch-derive/src/lib.rs
@@ -158,7 +158,7 @@ impl Patch {
                 type Output = Self;
 
                 fn shl(mut self, rhs: #name #generics) -> Self {
-                    self.apply(rhs);
+                    struct_patch::traits::Patch::apply(&mut self, rhs);
                     self
                 }
             }

--- a/struct-patch/Cargo.toml
+++ b/struct-patch/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-struct-patch-derive = { version = "=0.8.4", path = "../struct-patch-derive" }
+struct-patch-derive = { version = "=0.8.5", path = "../struct-patch-derive" }
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
Thanks for the time and effort you've put into this crate! ❤️ 

This fixes an issue when deriving `Patch` without importing the trait into the current scope.

As a quick illustration of the issue:

```rust
#[derive(::struct_patch::Patch)]
struct Data {}

fn main() {
}
```

This fails to compile with an error that goes something like this:

```text
error[E0599]: no method named `apply` found for struct `Data` in the current scope
```

So this is just a tiny one-line change that fixes that. I assumed Semantic Versioning or something similar, and bumped the patch version accordingly, since there's no change in functionality or anything.

Also while checking that it all worked, I noticed a minor warning from cargo:

```text
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
```

So I fixed that up too.

If you'd like me to change anything, just let me know! Thanks again for contributing something cool to the ecosystem!