### PR TITLE
DRAFT: chore(example-nesting): share the nesting example tests

### DIFF
--- a/example-nesting/.gitignore
+++ b/example-nesting/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/example-nesting/Cargo.toml
+++ b/example-nesting/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+[package]
+name = "example-nesting"
+publish = false
+edition = "2021"
+
+
+[dependencies]
+
+struct-patch = { path = "../struct-patch", features = ["nesting"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/example-nesting/src/lib.rs
+++ b/example-nesting/src/lib.rs
@@ -1,0 +1,39 @@
+use struct_patch::Patch;
+
+#[derive(Clone, Debug, Patch)]
+pub struct TopItem {
+    pub id: u8,
+
+    #[patch(nesting)]
+    pub child_item: ChildItem
+}
+
+#[derive(Clone, Debug, Patch)]
+pub struct ChildItem {
+    pub id: u8
+}
+
+
+#[cfg(test)]
+mod tests {
+    use struct_patch::Patch;
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let item_a = TopItem {
+            id: 10,
+            child_item: ChildItem { id: 20 }
+        };
+
+        let item_b = TopItem {
+            id: 10,
+            child_item: ChildItem { id: 30 }
+        };
+
+        let diff = item_b.into_patch_by_diff(item_a);
+
+        assert!(diff.id.is_none());
+        assert_eq!(diff.child_item.id, Some(30));
+    }
+}

--- a/example-nesting/src/lib.rs
+++ b/example-nesting/src/lib.rs
@@ -1,4 +1,4 @@
-use struct_patch::Patch;
+use struct_patch::{Patch, Status};
 
 #[derive(Clone, Debug, Patch)]
 pub struct TopItem {
@@ -35,5 +35,6 @@ mod tests {
 
         assert!(diff.id.is_none());
         assert_eq!(diff.child_item.id, Some(30));
+        assert!(!diff.is_empty());
     }
 }


### PR DESCRIPTION
Example of the problem I'm having with the "nesting" feature (https://github.com/yanganto/struct-patch/issues/97).

Here's the error message: 

```
cargo test
   Compiling example-nesting v0.0.0 (/mnt/workbench/toys/struct-patch/example-nesting)
error[E0063]: missing field `child_item` in initializer of `TopItemPatch`
 --> src/lib.rs:3:24
  |
3 | #[derive(Clone, Debug, Patch)]
  |                        ^^^^^ missing `child_item`
  |
  = note: this error originates in the derive macro `Patch` (in Nightly builds, run with -Z macro-backtrace for more info)
```