### PR TITLE
Bump toml from 0.8 to 0.9

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,7 @@ struct-patch-derive = { version = "=0.10.5", path = "../derive" }
 serde_json = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.9.0"
-toml = "0.8.19"
+toml = "0.9"
 humantime-serde = "1.1.1"
 clap = { version = "4.4.7", features = ["derive"] }
 


### PR DESCRIPTION
Bumps `toml` in `lib/Cargo.toml` from `0.8.19` to `0.9` (stable since 2025-08-29).

The two call sites are in `lib/examples/time.rs`, both using `toml::from_str`. That API is stable across the transition, so no source changes are required.

### Verification

* `cargo build`: clean
* `cargo test`: clean (no tests in crate)

Pre-existing `cargo clippy --all-targets -- -D warnings` errors (2) and `cargo fmt --check` noise are reproducible on vanilla `main` before this change.

### Context

Part of the Debian Rust team's `toml 0.9` transition (debcargo-conf#147). struct-patch is one of the reverse-dependencies currently on 0.8.
